### PR TITLE
Fix test reliability by using dummy file for git detection

### DIFF
--- a/tests/test-quality-gate-integration.sh
+++ b/tests/test-quality-gate-integration.sh
@@ -29,6 +29,10 @@ TEST_DIR="/tmp/quality-gate-test-$$-$(date +%s)"
 TEST_TRANSCRIPT="$TEST_DIR/test-transcript.jsonl"
 mkdir -p "$TEST_DIR"
 
+# Create a temporary file to ensure git detects changes
+TEST_DUMMY_FILE=".test-dummy-$$"
+touch "$TEST_DUMMY_FILE"
+
 # Test result tracking
 PASSED_TESTS=0
 FAILED_TESTS=0
@@ -255,5 +259,6 @@ fi
 
 # Cleanup
 rm -rf "$TEST_DIR"
+rm -f "$TEST_DUMMY_FILE"
 
 exit $exit_code

--- a/tests/test-quality-gate-integration.sh
+++ b/tests/test-quality-gate-integration.sh
@@ -29,9 +29,12 @@ TEST_DIR="/tmp/quality-gate-test-$$-$(date +%s)"
 TEST_TRANSCRIPT="$TEST_DIR/test-transcript.jsonl"
 mkdir -p "$TEST_DIR"
 
-# Create a temporary file to ensure git detects changes
-TEST_DUMMY_FILE=".test-dummy-$$"
+# Create a temporary file under the repo root to ensure git detects changes
+TEST_DUMMY_FILE="$PROJECT_ROOT/.test-dummy-$$"
 touch "$TEST_DUMMY_FILE"
+
+# Ensure cleanup even on early exits
+trap 'rm -f "$TEST_DUMMY_FILE"; rm -rf "$TEST_DIR"' EXIT
 
 # Test result tracking
 PASSED_TESTS=0
@@ -257,8 +260,5 @@ else
     exit_code=1
 fi
 
-# Cleanup
-rm -rf "$TEST_DIR"
-rm -f "$TEST_DUMMY_FILE"
-
+# Cleanup is handled by trap
 exit $exit_code


### PR DESCRIPTION
# What
Tests create a temporary dummy file to ensure git detects changes, making quality-gate-stop.sh tests work reliably in clean environments.

# Why
Tests were failing locally when no git changes existed, as quality-gate-stop.sh skips execution without changes. CI passed due to permission changes from chmod operations creating detectable changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by creating and removing a temporary dummy file during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->