### PR TITLE
Add option to control quality gate execution outside git repos

### DIFF
--- a/.claude/scripts/common-config.sh
+++ b/.claude/scripts/common-config.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Common configuration for quality gate scripts
 
+# Run quality gate outside git repositories (default: false)
+# Set to true to enable quality gate checks in non-git directories
+QUALITY_GATE_RUN_OUTSIDE_GIT="${QUALITY_GATE_RUN_OUTSIDE_GIT:-false}"
+
 # Configurable pattern for file editing tools (for MCP compatibility)
 EDIT_TOOLS_PATTERN="${EDIT_TOOLS_PATTERN:-^(Write|Edit|MultiEdit|NotebookEdit)$}"
 

--- a/.claude/scripts/quality-gate-stop.sh
+++ b/.claude/scripts/quality-gate-stop.sh
@@ -53,7 +53,12 @@ fi
 if ! command -v git >/dev/null 2>&1; then
     echo "Git not available - proceeding with quality gate" >> "$LOG_FILE"
 elif ! git rev-parse --git-dir >/dev/null 2>&1; then
-    echo "Not in git repository - proceeding with quality gate" >> "$LOG_FILE"
+    if [[ "${QUALITY_GATE_RUN_OUTSIDE_GIT}" == "true" ]]; then
+        echo "Not in git repository - proceeding with quality gate (QUALITY_GATE_RUN_OUTSIDE_GIT=true)" >> "$LOG_FILE"
+    else
+        echo "Not in git repository - skipping quality gate (set QUALITY_GATE_RUN_OUTSIDE_GIT=true to run)" >> "$LOG_FILE"
+        exit 0
+    fi
 elif [[ -z $(git status --porcelain 2>/dev/null) ]]; then
     echo "No git changes detected - skipping quality gate" >> "$LOG_FILE"
     exit 0


### PR DESCRIPTION
# What
Added QUALITY_GATE_RUN_OUTSIDE_GIT environment variable to control whether quality gate runs outside git repositories. Defaults to false (skip).

# Why
Quality gate was always running outside git repos, causing unnecessary executions. Now it skips by default but can be enabled when needed.