### PR TITLE
Add quality gate status reporter script

### DIFF
--- a/.claude/scripts/quality-gate-status.sh
+++ b/.claude/scripts/quality-gate-status.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Quality gate status reporter for shell integration
+# Returns: APPROVED, REJECTED, PENDING, or DISABLED
+# With --emoji: ✅, ❌, ⏳, or 🔒
+# Exit codes: 0 for success, 1 for errors
+
+# Parse command line arguments
+EMOJI_MODE=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --emoji)
+            EMOJI_MODE=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: $0 [--emoji]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Default transcript path
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-/tmp/claude_transcript.jsonl}"
+
+# Source common configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common-config.sh"
+
+# Check dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq not found" >&2
+    exit 1
+fi
+
+# Check git status first (same logic as quality-gate-stop.sh)
+if ! command -v git >/dev/null 2>&1; then
+    # Git not available - quality gate is active
+    :
+elif ! git rev-parse --git-dir >/dev/null 2>&1; then
+    # Not in git repository
+    if [[ "${QUALITY_GATE_RUN_OUTSIDE_GIT}" != "true" ]]; then
+        if [[ "$EMOJI_MODE" == "true" ]]; then
+            echo "🔒"
+        else
+            echo "DISABLED"
+        fi
+        exit 0
+    fi
+elif [[ -z $(git status --porcelain 2>/dev/null) ]]; then
+    # No git changes - quality gate disabled
+    if [[ "$EMOJI_MODE" == "true" ]]; then
+        echo "🔒"
+    else
+        echo "DISABLED"
+    fi
+    exit 0
+fi
+
+# Check if transcript file exists
+if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
+    if [[ "$EMOJI_MODE" == "true" ]]; then
+        echo "⏳"
+    else
+        echo "PENDING"
+    fi
+    exit 0
+fi
+
+# Check retry limit
+if count_attempts_since_last_reset_point "$TRANSCRIPT_PATH" 10; then
+    # Auto-approved after max attempts
+    if [[ "$EMOJI_MODE" == "true" ]]; then
+        echo "✅"
+    else
+        echo "APPROVED"
+    fi
+    exit 0
+fi
+
+# Get quality result from transcript
+get_quality_result "$TRANSCRIPT_PATH"
+result=$?
+
+# Output status based on result
+if [[ "$EMOJI_MODE" == "true" ]]; then
+    case $result in
+        0)
+            echo "✅"
+            ;;
+        1)
+            echo "❌"
+            ;;
+        2)
+            echo "⏳"
+            ;;
+        *)
+            echo "⏳"
+            ;;
+    esac
+else
+    case $result in
+        0)
+            echo "APPROVED"
+            ;;
+        1)
+            echo "REJECTED"
+            ;;
+        2)
+            echo "PENDING"
+            ;;
+        *)
+            echo "PENDING"
+            ;;
+    esac
+fi
+
+exit 0

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Test quality-gate-pre-commit.sh syntax
       run: bash -n .claude/scripts/quality-gate-pre-commit.sh
     
+    - name: Test quality-gate-status.sh syntax
+      run: bash -n .claude/scripts/quality-gate-status.sh
+    
     - name: Run comprehensive function tests
       run: ./tests/test-functions.sh
     
@@ -40,6 +43,10 @@ jobs:
     
     - name: Run edge case tests
       run: ./tests/test-edge-cases.sh
+      if: always()
+    
+    - name: Run quality-gate-status tests
+      run: ./tests/test-quality-gate-status.sh
       if: always()
     
     - name: Test script dependencies

--- a/tests/test-quality-gate-status.sh
+++ b/tests/test-quality-gate-status.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Test for quality-gate-status.sh
+
+set -e
+
+# Source test data  
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$TESTS_DIR/test-data-common.sh"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Test counter
+test_count=0
+pass_count=0
+
+# Store original directory
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$PROJECT_ROOT/.claude/scripts/quality-gate-status.sh"
+
+# Test function
+test_status() {
+    local test_name="$1"
+    local expected="$2"
+    local setup_func="$3"
+    
+    ((test_count++))
+    
+    # Setup test environment
+    rm -f test_transcript.jsonl
+    $setup_func
+    
+    # Run the script
+    local result=$(TRANSCRIPT_PATH=test_transcript.jsonl "$SCRIPT_PATH")
+    
+    if [[ "$result" == "$expected" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name: $result"
+        ((pass_count++))
+    else
+        echo -e "${RED}✗${NC} $test_name: expected '$expected', got '$result'"
+    fi
+    
+    rm -f test_transcript.jsonl
+}
+
+# Setup functions for different states
+setup_approved() {
+    get_data "APPROVE_RESULT" > test_transcript.jsonl
+}
+
+setup_rejected() {
+    get_data "REJECT_RESULT" > test_transcript.jsonl
+}
+
+setup_pending() {
+    # No Final Result in transcript (just regular assistant response)
+    get_data "ASSISTANT_RESPONSE" > test_transcript.jsonl
+}
+
+setup_empty() {
+    # Empty transcript file
+    touch test_transcript.jsonl
+}
+
+setup_no_file() {
+    # No transcript file at all
+    rm -f test_transcript.jsonl
+}
+
+setup_stale_approval() {
+    # APPROVED but then file edited
+    get_data "APPROVE_RESULT" > test_transcript.jsonl
+    echo '{"message":{"content":[{"name":"Edit"}]}}' >> test_transcript.jsonl
+}
+
+# Additional setup functions for git-related tests
+setup_disabled_no_changes() {
+    # Simulate no git changes by using env variable
+    # Since we can't cd to create a clean git repo, we'll test with env override
+    touch test_transcript.jsonl
+    # This test would require actual git state manipulation which is limited
+    # So we'll skip this particular scenario in the test
+}
+
+setup_disabled_not_in_git() {
+    # Test with QUALITY_GATE_RUN_OUTSIDE_GIT=false (default)
+    # This should return DISABLED when not in git repo
+    touch test_transcript.jsonl
+}
+
+setup_auto_approved() {
+    # Create transcript with many stop hook attempts (>10)
+    {
+        get_data "USER_INPUT"
+        for i in {1..11}; do
+            get_data "STOP_HOOK_FEEDBACK"
+        done
+    } > test_transcript.jsonl
+}
+
+# Test function for emoji mode
+test_emoji_status() {
+    local test_name="$1"
+    local expected="$2"
+    local setup_func="$3"
+    
+    ((test_count++))
+    
+    # Setup test environment
+    rm -f test_transcript.jsonl
+    $setup_func
+    
+    # Run the script with --emoji flag
+    local result=$(TRANSCRIPT_PATH=test_transcript.jsonl "$SCRIPT_PATH" --emoji)
+    
+    if [[ "$result" == "$expected" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name (emoji): $result"
+        ((pass_count++))
+    else
+        echo -e "${RED}✗${NC} $test_name (emoji): expected '$expected', got '$result'"
+    fi
+    
+    rm -f test_transcript.jsonl
+}
+
+# Run tests
+echo "Running quality-gate-status.sh tests..."
+echo
+
+# Test normal mode
+echo "=== Normal mode tests ==="
+test_status "APPROVED state" "APPROVED" setup_approved
+test_status "REJECTED state" "REJECTED" setup_rejected
+test_status "PENDING state (no result)" "PENDING" setup_pending
+test_status "PENDING state (empty file)" "PENDING" setup_empty
+test_status "PENDING state (no file)" "PENDING" setup_no_file
+test_status "PENDING state (stale approval)" "PENDING" setup_stale_approval
+test_status "AUTO-APPROVED state (max attempts)" "APPROVED" setup_auto_approved
+
+echo
+echo "=== Emoji mode tests ==="
+test_emoji_status "APPROVED state" "✅" setup_approved
+test_emoji_status "REJECTED state" "❌" setup_rejected
+test_emoji_status "PENDING state (no result)" "⏳" setup_pending
+test_emoji_status "PENDING state (empty file)" "⏳" setup_empty
+test_emoji_status "PENDING state (no file)" "⏳" setup_no_file
+test_emoji_status "PENDING state (stale approval)" "⏳" setup_stale_approval
+test_emoji_status "AUTO-APPROVED state (max attempts)" "✅" setup_auto_approved
+
+echo
+echo "Tests completed: $pass_count/$test_count passed"
+
+if [[ $pass_count -eq $test_count ]]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
# What
Add quality-gate-status.sh script that reports the current quality gate status for shell integration.

# Why
Enable status line integration to display quality gate state (APPROVED/REJECTED/PENDING/DISABLED) with optional emoji output for better visibility in terminal prompts.