### PR TITLE
Add review step after fixes in reject message flow

### DIFF
--- a/.claude/scripts/quality-gate-pre-commit.sh
+++ b/.claude/scripts/quality-gate-pre-commit.sh
@@ -22,12 +22,16 @@ if [[ "$command" =~ (^|[[:space:];&|])git[[:space:]]+.*commit([[:space:]]|$) ]];
             echo "❌ Quality gate REJECTED - commit blocked due to critical issues" >&2
             echo "Step 1: Use Task tool with subagent_type='quality-gate-keeper' to review and identify issues" >&2
             echo "Step 2: Fix any issues identified by the quality gate keeper" >&2
+            echo "Step 3: Use Task tool with subagent_type='quality-gate-keeper' to review the fixes" >&2
+            echo "Step 4: Commit when you get APPROVED status" >&2
             exit 2
             ;;
         2)  # No verdict found
             echo "🔍 Quality check required:" >&2
             echo "Step 1: Use Task tool with subagent_type='quality-gate-keeper' to perform quality inspection" >&2
             echo "Step 2: Fix any issues identified by the quality gate keeper" >&2
+            echo "Step 3: Use Task tool with subagent_type='quality-gate-keeper' to review the fixes" >&2
+            echo "Step 4: Commit when you get APPROVED status" >&2
             exit 2
             ;;
     esac


### PR DESCRIPTION
# What
Updated quality gate reject messages to include a 4-step workflow that adds review after fixes before allowing commit.

# Why
Ensures users verify their fixes actually resolve quality issues before attempting to commit again, preventing incomplete fixes from being committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit quality gate messaging with clearer next steps when checks are rejected or no verdict is found. After existing guidance, the tool now prompts Step 3 to review fixes with the Task tool and Step 4 to commit once approved.
  * Improves developer guidance without altering logic: approval flow, decision thresholds, and exit statuses remain unchanged (non-zero on rejection/no verdict; approved path unaffected).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->