### PR TITLE
Improve README section title for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This validates the entire workflow from test creation to quality intervention.
 
 ## Key Features
 
-### Direct Verdict System
+### System Behavior
 The system uses quality-gate-keeper's direct output for decision making:
 
 1. **Direct Result Checking**: Parses transcript for `Final Result: ✅ APPROVED` or `Final Result: ❌ REJECTED`


### PR DESCRIPTION
# What
Changed README.md section title from "Direct Verdict System" to "System Behavior" to improve documentation clarity.

# Why
The original title "Direct Verdict System" was confusing and potentially meaningless to readers. "System Behavior" more clearly describes what the section explains - how the quality gate system operates.