### PR TITLE
Fix parallel execution safety for temporary files

### DIFF
--- a/.claude/scripts/common-config.sh
+++ b/.claude/scripts/common-config.sh
@@ -279,7 +279,7 @@ count_attempts_since_last_reset_point() {
     # Stop hook messages appear in tool_use commands within assistant messages
     local attempt_count=0
     local temp_transcript
-    temp_transcript="$(mktemp "${TMPDIR:-/tmp}/filtered_transcript.XXXXXX.jsonl")"
+    temp_transcript="$(mktemp -t filtered_transcript.$$.XXXXXX)" && temp_transcript="${temp_transcript}.jsonl"
     trap 'rm -f "$temp_transcript"' RETURN
     
     if [[ $start_line -gt 0 ]]; then

--- a/.claude/scripts/common-config.sh
+++ b/.claude/scripts/common-config.sh
@@ -279,8 +279,8 @@ count_attempts_since_last_reset_point() {
     # Stop hook messages appear in tool_use commands within assistant messages
     local attempt_count=0
     local temp_transcript
-    temp_transcript="$(mktemp -t filtered_transcript.$$.XXXXXX)" && temp_transcript="${temp_transcript}.jsonl"
-    trap 'rm -f "$temp_transcript"' RETURN
+    temp_transcript="$(mktemp "${TMPDIR:-/tmp}"/filtered_transcript.$$.XXXXXX.jsonl)"
+    trap 'rm -f -- "$temp_transcript"' RETURN
     
     if [[ $start_line -gt 0 ]]; then
         # Extract lines after start_line

--- a/tests/test-functions.sh
+++ b/tests/test-functions.sh
@@ -283,7 +283,7 @@ test_large_file_performance() {
     # - Many user messages (simulate ~500-1000)
     # - Multiple Final Result entries
     local large_perf_test
-    large_perf_test="$(mktemp "${TMPDIR:-/tmp}/large-perf-test.XXXXXX.jsonl")"
+    large_perf_test="$(mktemp -t large-perf-test.$$.XXXXXX)" && large_perf_test="${large_perf_test}.jsonl"
     echo "# Large performance test" > "$large_perf_test"
     trap 'rm -f "$large_perf_test"' RETURN
     
@@ -353,7 +353,7 @@ test_count_attempts_performance() {
     echo "Test 17: count_attempts_since_last_reset_point performance"
     
     local large_count_test
-    large_count_test="$(mktemp "${TMPDIR:-/tmp}/large-count-test.XXXXXX.jsonl")"
+    large_count_test="$(mktemp -t large-count-test.$$.XXXXXX)" && large_count_test="${large_count_test}.jsonl"
     echo "# Large count test" > "$large_count_test"
     trap 'rm -f "$large_count_test"' RETURN
     

--- a/tests/test-functions.sh
+++ b/tests/test-functions.sh
@@ -283,9 +283,9 @@ test_large_file_performance() {
     # - Many user messages (simulate ~500-1000)
     # - Multiple Final Result entries
     local large_perf_test
-    large_perf_test="$(mktemp -t large-perf-test.$$.XXXXXX)" && large_perf_test="${large_perf_test}.jsonl"
+    large_perf_test="$(mktemp "${TMPDIR:-/tmp}"/large-perf-test.$$.XXXXXX.jsonl)"
     echo "# Large performance test" > "$large_perf_test"
-    trap 'rm -f "$large_perf_test"' RETURN
+    trap 'rm -f -- "$large_perf_test"' RETURN
     
     # Add many user messages to trigger the bottleneck (match real-world scenario)
     echo "Creating large test file with 800 user messages..."
@@ -353,9 +353,9 @@ test_count_attempts_performance() {
     echo "Test 17: count_attempts_since_last_reset_point performance"
     
     local large_count_test
-    large_count_test="$(mktemp -t large-count-test.$$.XXXXXX)" && large_count_test="${large_count_test}.jsonl"
+    large_count_test="$(mktemp "${TMPDIR:-/tmp}"/large-count-test.$$.XXXXXX.jsonl)"
     echo "# Large count test" > "$large_count_test"
-    trap 'rm -f "$large_count_test"' RETURN
+    trap 'rm -f -- "$large_count_test"' RETURN
     
     # Create scenario that triggers the slow path in count_attempts_since_last_reset_point:
     # LOTS of user messages + mixed Final Result entries (this is what's slow)


### PR DESCRIPTION
# What
Fixed temporary file creation to prevent collisions when multiple Claude Code instances run simultaneously by adding process ID to mktemp patterns.

# Why
Claude Code can run in parallel, causing temporary file name collisions with hardcoded paths. The mktemp pattern needed process-specific prefixes to ensure unique file names across concurrent sessions.

Changed from TMPDIR-based paths to mktemp -t with process ID ($$) for guaranteed uniqueness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved temporary file handling to include process identifiers and safer cleanup, reducing filename collisions and handling edge-case names reliably.

- Tests
  - Updated performance tests to use the same robust temporary file strategy and safer removal, improving test stability and consistent setup/teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->