### PR TITLE
Fix git index.lock conflicts in quality gate scripts

### DIFF
--- a/.claude/scripts/quality-gate-status.sh
+++ b/.claude/scripts/quality-gate-status.sh
@@ -57,7 +57,7 @@ elif ! git rev-parse --git-dir >/dev/null 2>&1; then
         fi
         exit 0
     fi
-elif [[ -z $(git status --porcelain 2>/dev/null) ]]; then
+elif [[ -z $(git diff --name-only 2>/dev/null) ]] && [[ -z $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
     # No git changes - quality gate disabled
     if [[ "$EMOJI_MODE" == "true" ]]; then
         echo "🔒"

--- a/.claude/scripts/quality-gate-stop.sh
+++ b/.claude/scripts/quality-gate-stop.sh
@@ -63,7 +63,7 @@ elif ! git rev-parse --git-dir >/dev/null 2>&1; then
         echo "Not in git repository - skipping quality gate (set QUALITY_GATE_RUN_OUTSIDE_GIT=true to run)" >> "$LOG_FILE"
         exit 0
     fi
-elif [[ -z $(git status --porcelain 2>/dev/null) ]]; then
+elif [[ -z $(git diff --name-only 2>/dev/null) ]] && [[ -z $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
     echo "No git changes detected - skipping quality gate" >> "$LOG_FILE"
     exit 0
 else


### PR DESCRIPTION
# What
Replace `git status --porcelain` with read-only git commands (`git diff --name-only` and `git ls-files --others --exclude-standard`) in quality gate scripts to prevent index.lock file conflicts.

# Why
When multiple git commands run concurrently (e.g., from statusLine and quality gate hooks), `git status` can create index.lock files that cause "index.lock already exists" errors. The new approach uses read-only operations that don't create lock files, eliminating the conflict.