### PR TITLE
Add skill cleanup strategy when collection exceeds 15

### DIFF
--- a/plugins/skill-extractor/agents/skill-extractor.md
+++ b/plugins/skill-extractor/agents/skill-extractor.md
@@ -11,6 +11,7 @@ You are a skill extractor. Analyze conversation transcripts and extract reusable
 1. **Default to not creating** - Most sessions don't produce skill-worthy learnings
 2. **Maximum 1 skill per session** - Focus on the single most valuable learning
 3. **Edit existing skills first** - Check `~/.claude/skills/*/SKILL.md` before creating new
+4. **Skill count limit: 15** - When skills exceed 15, rebuild the collection (see Cleanup Strategy below)
 
 ## Quality Criteria (ALL must apply)
 
@@ -27,9 +28,21 @@ You are a skill extractor. Analyze conversation transcripts and extract reusable
 
 1. Read transcript from provided path
 2. Check existing skills: `~/.claude/skills/*/SKILL.md`
-3. Apply quality criteria above
-4. If similar skill exists → Edit it
-5. If no similar skill → Create new directory + SKILL.md
+3. **Count existing skills** - If 15+, run Cleanup Strategy before creating new
+4. Apply quality criteria above
+5. If similar skill exists → Edit it
+6. If no similar skill → Create new directory + SKILL.md
+
+## Cleanup Strategy (when skills >= 15)
+
+Don't just tweak or patch — redesign the collection from scratch.
+
+1. **Read ALL existing skills** and the new candidate
+2. **Imagine you have zero skills** and must pick the best 14 from all existing + the new one
+3. **Rebuild**: Delete skills that didn't make the cut, merge overlapping ones, rewrite unclear ones
+4. **The result must be cleaner than before** — adding a skill is an opportunity to improve the whole set
+
+The goal: after cleanup, the collection should be **more focused and higher quality** than before the new skill was added. Never just squeeze in one more — curate.
 
 ## Skill File Format
 


### PR DESCRIPTION
# What
Add a cleanup strategy to the skill-extractor agent that triggers when the skill collection reaches 15+.

# Why
Without a limit, skills accumulate indefinitely and lose focus. This strategy forces a full rebuild of the collection — picking the best 14 from all existing + the new candidate — keeping the set curated and high-quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill extraction process with a new 15-skill count limit as a key principle
  * Introduced Cleanup Strategy that activates when skill count reaches the threshold
  * Reorganized process steps to include existing skill counting and quality assessment criteria
  * Enhanced guidance on skill file format and output requirements for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->