### PR TITLE
Instruct hooks to run subagents in foreground

### DIFF
--- a/plugins/claude-code-quality-gate/scripts/quality-gate-pre-commit.sh
+++ b/plugins/claude-code-quality-gate/scripts/quality-gate-pre-commit.sh
@@ -20,17 +20,17 @@ if [[ "$command" =~ (^|[[:space:];&|])git[[:space:]]+.*commit([[:space:]]|$) ]];
             ;;
         1)  # REJECTED
             echo "❌ Quality gate REJECTED - commit blocked due to critical issues" >&2
-            echo "Step 1: Use Task tool with subagent_type='quality-gate-keeper' to review and identify issues" >&2
+            echo "Step 1: Use Task tool with subagent_type='quality-gate-keeper' (run it in the foreground with background: false) to review and identify issues" >&2
             echo "Step 2: Fix any issues identified by the quality gate keeper" >&2
-            echo "Step 3: Use Task tool with subagent_type='quality-gate-keeper' to review the fixes" >&2
+            echo "Step 3: Use Task tool with subagent_type='quality-gate-keeper' (run it in the foreground with background: false) to review the fixes" >&2
             echo "Step 4: Commit when you get APPROVED status" >&2
             exit 2
             ;;
         2)  # No verdict found
             echo "🔍 Quality check required:" >&2
-            echo "Step 1: Use Task tool with subagent_type='quality-gate-keeper' to perform quality inspection" >&2
+            echo "Step 1: Use Task tool with subagent_type='quality-gate-keeper' (run it in the foreground with background: false) to perform quality inspection" >&2
             echo "Step 2: Fix any issues identified by the quality gate keeper" >&2
-            echo "Step 3: Use Task tool with subagent_type='quality-gate-keeper' to review the fixes" >&2
+            echo "Step 3: Use Task tool with subagent_type='quality-gate-keeper' (run it in the foreground with background: false) to review the fixes" >&2
             echo "Step 4: Commit when you get APPROVED status" >&2
             exit 2
             ;;

--- a/plugins/claude-code-quality-gate/scripts/quality-gate-stop.sh
+++ b/plugins/claude-code-quality-gate/scripts/quality-gate-stop.sh
@@ -72,7 +72,7 @@ fi
 
 # Trigger quality intervention with automatic subagent launch
 echo "❌ STOP: Quality gate blocking session completion.
-➡️ Step 1: Use Task tool with subagent_type='quality-gate-keeper' to review code quality
+➡️ Step 1: Use Task tool with subagent_type='quality-gate-keeper' (run it in the foreground with background: false) to review code quality
 ➡️ Step 2: Fix any issues identified by the quality gate keeper 
 🔍 Purpose: Thorough code quality inspection required
 🔄 This message repeats until proper quality review completed" >&2

--- a/plugins/skill-extractor/scripts/check-for-learnings.sh
+++ b/plugins/skill-extractor/scripts/check-for-learnings.sh
@@ -28,5 +28,5 @@ fi
 # Suggest skill extraction with transcript path (use jq for safe JSON escaping)
 jq -n --arg path "$transcript_path" '{
   decision: "block",
-  reason: "Consider extracting learnings from this session. Use the skill-extractor agent to analyze the conversation at \($path) and save valuable patterns as skills."
+  reason: "Consider extracting learnings from this session. Use the skill-extractor agent (run it in the foreground with background: false) to analyze the conversation at \($path) and save valuable patterns as skills."
 }'


### PR DESCRIPTION
# What
Add an explicit instruction to run subagents in the foreground (`background: false`) to the subagent-launch messages emitted by three hook scripts:
- `skill-extractor/scripts/check-for-learnings.sh`
- `claude-code-quality-gate/scripts/quality-gate-stop.sh`
- `claude-code-quality-gate/scripts/quality-gate-pre-commit.sh`

# Why
Subagents recently became background by default. These hooks expect the launched subagent's result inline before the session continues, so they should run in the foreground.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated on-screen step-by-step guidance in quality gate and skill extraction scripts for clearer, multi-line instructions.
  * Added explicit foreground execution guidance (`background: false`) for the recommended task run steps.
* **Bug Fixes**
  * Improved blocking and no-verdict messages so the next action is easier to follow when the quality gate stops completion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->