### PR TITLE
Make quality gate idempotent and diff against main branch

### DIFF
--- a/plugins/claude-code-quality-gate/.claude-plugin/plugin.json
+++ b/plugins/claude-code-quality-gate/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "claude-code-quality-gate",
     "description": "Quality gate automation using Claude Code hooks and subagents.",
-    "version": "1.0.0"
+    "version": "1.1.0"
 }

--- a/plugins/claude-code-quality-gate/README.md
+++ b/plugins/claude-code-quality-gate/README.md
@@ -97,9 +97,10 @@ This validates the entire workflow from test creation to quality intervention.
 The system uses quality-gate-keeper's direct output for decision making:
 
 1. **Direct Result Checking**: Parses transcript for `Final Result: ✅ APPROVED` or `Final Result: ❌ REJECTED`
-2. **Stale Approval Detection**: Automatically invalidates old approvals after file edits
-3. **Manual Override**: Type `SKIP QG` to bypass quality gate checks when needed
-4. **Loop Prevention**: Automatically stops after 10 quality check attempts to prevent infinite loops
+2. **Diff Base**: Changes are measured against the merge-base with `main` (configurable via `QUALITY_GATE_DIFF_BASE`), so committed-but-unmerged work is reviewed too — not just the working tree
+3. **Stale Approval Detection (idempotent)**: Invalidates old approvals after real edits, but if the diff is byte-identical to what was approved, the gate stays green and does not re-launch — so it won't loop on an unchanged diff
+4. **Manual Override**: Type `SKIP QG` to bypass quality gate checks when needed
+5. **Loop Prevention**: Automatically stops after 10 quality check attempts to prevent infinite loops
 
 
 ## Important Notes

--- a/plugins/claude-code-quality-gate/agents/quality-gate-keeper.md
+++ b/plugins/claude-code-quality-gate/agents/quality-gate-keeper.md
@@ -14,7 +14,12 @@ You are a quality gate keeper. Your role is to:
 
 ## Quality Gate Process
 1. **Focus ONLY on current session changes** - do NOT analyze entire codebase
-2. **Identify actual changes made** - use git diff or explicit file list
+2. **Identify actual changes made** - diff against the main branch, not just the working tree, so committed-but-unmerged work is reviewed too:
+   ```bash
+   BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null)
+   git diff "$BASE"                          # tracked changes since branching from main
+   git ls-files --others --exclude-standard  # new untracked files
+   ```
 3. **Check only modified files** - ignore unchanged existing code
 4. **Run ONLY relevant tests** - not the entire test suite:
    - Tests for modified files only

--- a/plugins/claude-code-quality-gate/scripts/common-config.sh
+++ b/plugins/claude-code-quality-gate/scripts/common-config.sh
@@ -20,6 +20,20 @@ fi
 # Set to true to enable quality gate checks in non-git directories
 QUALITY_GATE_RUN_OUTSIDE_GIT="${QUALITY_GATE_RUN_OUTSIDE_GIT:-false}"
 
+# 差分の基準ブランチ（デフォルト: main）。作業ツリーだけでなく main との
+# マージベースからの差分をレビュー対象にするために使う。
+QUALITY_GATE_DIFF_BASE="${QUALITY_GATE_DIFF_BASE:-main}"
+
+# ハッシュコマンド（macOS は shasum、GNU は sha1sum）。どちらも無ければ
+# 空にして冪等判定を無効化する（従来の編集検知にフォールバック）。
+if command -v shasum >/dev/null 2>&1; then
+    QG_HASH_CMD="shasum"
+elif command -v sha1sum >/dev/null 2>&1; then
+    QG_HASH_CMD="sha1sum"
+else
+    QG_HASH_CMD=""
+fi
+
 # Configurable pattern for file editing tools (for MCP compatibility)
 # Support both old and new variable names for backward compatibility
 # Includes standard tools and serena MCP tools
@@ -34,6 +48,92 @@ check_dependencies() {
             exit 1
         fi
     done
+}
+
+# main ブランチとのマージベースを解決する
+# 出力: マージベースのコミットハッシュ / 見つからなければ非ゼロで返す
+quality_gate_diff_base() {
+    local base="$QUALITY_GATE_DIFF_BASE"
+    local ref=""
+    # ローカルブランチ → リモート追跡の順に解決する
+    if git rev-parse --verify --quiet "$base" >/dev/null 2>&1; then
+        ref="$base"
+    elif git rev-parse --verify --quiet "origin/$base" >/dev/null 2>&1; then
+        ref="origin/$base"
+    else
+        return 1
+    fi
+    git merge-base HEAD "$ref" 2>/dev/null
+}
+
+# レビュー対象の変更が存在するか判定する
+# 未追跡ファイル、および main とのマージベースからの差分（コミット済み含む）を見る
+# base が解決できない場合は従来どおり作業ツリーの差分にフォールバックする
+# 返り値: 0 = 変更あり / 1 = 変更なし
+quality_gate_has_changes() {
+    if [[ -n $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
+        return 0
+    fi
+    local base
+    if base=$(quality_gate_diff_base); then
+        if ! git diff --quiet "$base" 2>/dev/null; then
+            return 0
+        fi
+        return 1
+    fi
+    if [[ -n $(git diff --name-only 2>/dev/null) ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# 現在の差分（base からの差分 + 未追跡ファイルの内容）のハッシュを出力する
+# 承認時点の状態を記録し「承認後に実質的な変更がないか」を判定するために使う
+# git やハッシュコマンドが無い場合は空文字を返し、冪等判定を無効化する
+quality_gate_diff_hash() {
+    [[ -n "$QG_HASH_CMD" ]] || return 0
+    command -v git >/dev/null 2>&1 || return 0
+    git rev-parse --git-dir >/dev/null 2>&1 || return 0
+    local base
+    base=$(quality_gate_diff_base) || base=""
+    {
+        if [[ -n "$base" ]]; then
+            git diff "$base" 2>/dev/null
+        else
+            git diff 2>/dev/null
+        fi
+        # 未追跡ファイルの内容も差分に含める
+        git ls-files --others --exclude-standard -z 2>/dev/null \
+          | while IFS= read -r -d '' f; do
+                echo "=== $f ==="
+                cat -- "$f" 2>/dev/null
+            done
+    } | $QG_HASH_CMD | awk '{print $1}'
+}
+
+# 承認済み差分ハッシュを保存する状態ファイルのパスを出力する
+# QUALITY_GATE_STATE_FILE で上書き可能（主にテスト用）
+quality_gate_state_file() {
+    if [[ -n "${QUALITY_GATE_STATE_FILE:-}" ]]; then
+        echo "$QUALITY_GATE_STATE_FILE"
+        return 0
+    fi
+    local root
+    root=$(git rev-parse --show-toplevel 2>/dev/null) || root="$PWD"
+    local key="unknown"
+    if [[ -n "$QG_HASH_CMD" ]]; then
+        key=$(printf '%s' "$root" | $QG_HASH_CMD | awk '{print $1}')
+    fi
+    echo "${TMPDIR:-/tmp}/claude_quality_gate_approved-$key"
+}
+
+# APPROVED かつ現在の差分と一致することが確定した時点で差分ハッシュを記録する
+# これにより次回以降、差分が変わらなければ再レビューをスキップできる（冪等化）
+record_quality_gate_approval() {
+    local h
+    h=$(quality_gate_diff_hash)
+    [[ -z "$h" ]] && return 0
+    printf '%s\n' "$h" > "$(quality_gate_state_file)" 2>/dev/null || true
 }
 
 # Helper: Check for edits after given line number
@@ -146,6 +246,14 @@ get_quality_result() {
     if echo "$last_result" | grep -qE "✅.*APPROVED"; then
         # Check for file edits after approval
         if has_edits_after_line "$transcript_path" "$last_result_line"; then
+            # 承認後に編集はあるが、差分が承認時点と同一なら実質無変更なので
+            # 再レビューを促さず承認扱いにする（冪等化）
+            local approved_hash current_hash
+            approved_hash=$(cat "$(quality_gate_state_file)" 2>/dev/null)
+            current_hash=$(quality_gate_diff_hash)
+            if [[ -n "$approved_hash" && -n "$current_hash" && "$approved_hash" == "$current_hash" ]]; then
+                return 0  # 承認時点から差分が変わっていない
+            fi
             return 2  # Stale approval
         fi
         return 0  # APPROVED

--- a/plugins/claude-code-quality-gate/scripts/common-config.sh
+++ b/plugins/claude-code-quality-gate/scripts/common-config.sh
@@ -20,12 +20,12 @@ fi
 # Set to true to enable quality gate checks in non-git directories
 QUALITY_GATE_RUN_OUTSIDE_GIT="${QUALITY_GATE_RUN_OUTSIDE_GIT:-false}"
 
-# 差分の基準ブランチ（デフォルト: main）。作業ツリーだけでなく main との
-# マージベースからの差分をレビュー対象にするために使う。
+# Base branch for the review diff (default: main). Used to review the diff
+# from the merge-base with main, not just the working tree.
 QUALITY_GATE_DIFF_BASE="${QUALITY_GATE_DIFF_BASE:-main}"
 
-# ハッシュコマンド（macOS は shasum、GNU は sha1sum）。どちらも無ければ
-# 空にして冪等判定を無効化する（従来の編集検知にフォールバック）。
+# Hash command (shasum on macOS, sha1sum on GNU). If neither exists, leave it
+# empty to disable idempotency checks (falls back to legacy edit detection).
 if command -v shasum >/dev/null 2>&1; then
     QG_HASH_CMD="shasum"
 elif command -v sha1sum >/dev/null 2>&1; then
@@ -50,12 +50,12 @@ check_dependencies() {
     done
 }
 
-# main ブランチとのマージベースを解決する
-# 出力: マージベースのコミットハッシュ / 見つからなければ非ゼロで返す
+# Resolve the merge-base with the main branch
+# Output: merge-base commit hash / returns non-zero if not found
 quality_gate_diff_base() {
     local base="$QUALITY_GATE_DIFF_BASE"
     local ref=""
-    # ローカルブランチ → リモート追跡の順に解決する
+    # Resolve the local branch first, then the remote-tracking branch
     if git rev-parse --verify --quiet "$base" >/dev/null 2>&1; then
         ref="$base"
     elif git rev-parse --verify --quiet "origin/$base" >/dev/null 2>&1; then
@@ -66,10 +66,11 @@ quality_gate_diff_base() {
     git merge-base HEAD "$ref" 2>/dev/null
 }
 
-# レビュー対象の変更が存在するか判定する
-# 未追跡ファイル、および main とのマージベースからの差分（コミット済み含む）を見る
-# base が解決できない場合は従来どおり作業ツリーの差分にフォールバックする
-# 返り値: 0 = 変更あり / 1 = 変更なし
+# Check whether there are any changes to review
+# Looks at untracked files and the diff from the merge-base with main
+# (including committed changes). Falls back to the legacy working-tree
+# diff when the base cannot be resolved.
+# Returns: 0 = changes exist / 1 = no changes
 quality_gate_has_changes() {
     if [[ -n $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
         return 0
@@ -87,9 +88,10 @@ quality_gate_has_changes() {
     return 1
 }
 
-# 現在の差分（base からの差分 + 未追跡ファイルの内容）のハッシュを出力する
-# 承認時点の状態を記録し「承認後に実質的な変更がないか」を判定するために使う
-# git やハッシュコマンドが無い場合は空文字を返し、冪等判定を無効化する
+# Output a hash of the current diff (diff from base + untracked file contents)
+# Used to record the state at approval time and detect whether anything
+# effectively changed after approval.
+# Returns an empty string (disabling idempotency) without git or a hash command.
 quality_gate_diff_hash() {
     [[ -n "$QG_HASH_CMD" ]] || return 0
     command -v git >/dev/null 2>&1 || return 0
@@ -102,7 +104,7 @@ quality_gate_diff_hash() {
         else
             git diff 2>/dev/null
         fi
-        # 未追跡ファイルの内容も差分に含める
+        # Include untracked file contents in the hashed diff
         git ls-files --others --exclude-standard -z 2>/dev/null \
           | while IFS= read -r -d '' f; do
                 echo "=== $f ==="
@@ -111,8 +113,8 @@ quality_gate_diff_hash() {
     } | $QG_HASH_CMD | awk '{print $1}'
 }
 
-# 承認済み差分ハッシュを保存する状態ファイルのパスを出力する
-# QUALITY_GATE_STATE_FILE で上書き可能（主にテスト用）
+# Output the path of the state file that stores the approved diff hash
+# Can be overridden via QUALITY_GATE_STATE_FILE (mainly for tests)
 quality_gate_state_file() {
     if [[ -n "${QUALITY_GATE_STATE_FILE:-}" ]]; then
         echo "$QUALITY_GATE_STATE_FILE"
@@ -127,8 +129,8 @@ quality_gate_state_file() {
     echo "${TMPDIR:-/tmp}/claude_quality_gate_approved-$key"
 }
 
-# APPROVED かつ現在の差分と一致することが確定した時点で差分ハッシュを記録する
-# これにより次回以降、差分が変わらなければ再レビューをスキップできる（冪等化）
+# Record the diff hash once the result is APPROVED for the current diff
+# Later stops can then skip re-review as long as the diff is unchanged (idempotency)
 record_quality_gate_approval() {
     local h
     h=$(quality_gate_diff_hash)
@@ -246,13 +248,14 @@ get_quality_result() {
     if echo "$last_result" | grep -qE "✅.*APPROVED"; then
         # Check for file edits after approval
         if has_edits_after_line "$transcript_path" "$last_result_line"; then
-            # 承認後に編集はあるが、差分が承認時点と同一なら実質無変更なので
-            # 再レビューを促さず承認扱いにする（冪等化）
+            # Edits happened after approval, but if the diff is identical to
+            # the approved one, treat it as approved instead of prompting a
+            # re-review (idempotency)
             local approved_hash current_hash
             approved_hash=$(cat "$(quality_gate_state_file)" 2>/dev/null)
             current_hash=$(quality_gate_diff_hash)
             if [[ -n "$approved_hash" && -n "$current_hash" && "$approved_hash" == "$current_hash" ]]; then
-                return 0  # 承認時点から差分が変わっていない
+                return 0  # Diff is unchanged since approval
             fi
             return 2  # Stale approval
         fi

--- a/plugins/claude-code-quality-gate/scripts/quality-gate-status.sh
+++ b/plugins/claude-code-quality-gate/scripts/quality-gate-status.sh
@@ -57,8 +57,8 @@ elif ! git rev-parse --git-dir >/dev/null 2>&1; then
         fi
         exit 0
     fi
-elif [[ -z $(git diff --name-only 2>/dev/null) ]] && [[ -z $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
-    # No git changes - quality gate disabled
+elif ! quality_gate_has_changes; then
+    # No changes vs main - quality gate disabled
     if [[ "$EMOJI_MODE" == "true" ]]; then
         echo "🔒"
     else

--- a/plugins/claude-code-quality-gate/scripts/quality-gate-stop.sh
+++ b/plugins/claude-code-quality-gate/scripts/quality-gate-stop.sh
@@ -37,6 +37,8 @@ if [[ -f "$transcript_path" ]]; then
         0)  # APPROVED
             echo "Quality gate APPROVED detected" >> "$LOG_FILE"
             echo "Quality gate completed successfully!" >> "$LOG_FILE"
+            # 承認時点の差分を記録し、以降の Stop で無変更なら再レビューをスキップする
+            record_quality_gate_approval
             exit 0
             ;;
         1)  # REJECTED
@@ -63,11 +65,11 @@ elif ! git rev-parse --git-dir >/dev/null 2>&1; then
         echo "Not in git repository - skipping quality gate (set QUALITY_GATE_RUN_OUTSIDE_GIT=true to run)" >> "$LOG_FILE"
         exit 0
     fi
-elif [[ -z $(git diff --name-only 2>/dev/null) ]] && [[ -z $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
-    echo "No git changes detected - skipping quality gate" >> "$LOG_FILE"
+elif ! quality_gate_has_changes; then
+    echo "No changes vs ${QUALITY_GATE_DIFF_BASE} detected - skipping quality gate" >> "$LOG_FILE"
     exit 0
 else
-    echo "Git changes detected - proceeding with quality gate" >> "$LOG_FILE"
+    echo "Changes vs ${QUALITY_GATE_DIFF_BASE} detected - proceeding with quality gate" >> "$LOG_FILE"
 fi
 
 # Trigger quality intervention with automatic subagent launch

--- a/plugins/claude-code-quality-gate/scripts/quality-gate-stop.sh
+++ b/plugins/claude-code-quality-gate/scripts/quality-gate-stop.sh
@@ -37,7 +37,7 @@ if [[ -f "$transcript_path" ]]; then
         0)  # APPROVED
             echo "Quality gate APPROVED detected" >> "$LOG_FILE"
             echo "Quality gate completed successfully!" >> "$LOG_FILE"
-            # 承認時点の差分を記録し、以降の Stop で無変更なら再レビューをスキップする
+            # Record the approved diff so later stops skip re-review when unchanged
             record_quality_gate_approval
             exit 0
             ;;

--- a/tests/test-edge-cases.sh
+++ b/tests/test-edge-cases.sh
@@ -8,6 +8,10 @@ set +e
 # Source the common config to get the function
 source "$(dirname "$0")/../plugins/claude-code-quality-gate/scripts/common-config.sh"
 
+# 冪等判定の状態ファイルをテスト用に隔離する（既存の承認記録に汚染されないため）
+# デフォルトは存在しないパスにして「承認済み差分なし」を保証する
+export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-edge-state.XXXXXX")"
+
 # Test counter
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -98,6 +102,29 @@ test_stale_approval_detection() {
 {"parentUuid":"test-uuid","isSidechain":false,"userType":"external","sessionId":"test-session","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit"}]}}
 EOF
     run_test "Stale approval detection" 2 "stale_approval.jsonl"
+}
+
+test_idempotent_approval_unchanged_diff() {
+    echo "Test 7b: Idempotent approval - edits after APPROVED but diff unchanged should return 0"
+    cat > idempotent_approval.jsonl << 'EOF'
+{"parentUuid":"test-uuid","isSidechain":false,"userType":"external","sessionId":"test-session","type":"user","message":{"role":"user","content":[{"type":"text","text":"Hello"}]}}
+{"parentUuid":"test-uuid","isSidechain":true,"userType":"external","sessionId":"test-session","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Final Result: ✅ APPROVED - Code looks good"}]}}
+{"parentUuid":"test-uuid","isSidechain":false,"userType":"external","sessionId":"test-session","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit"}]}}
+EOF
+    # 承認時点の差分ハッシュを現在の差分に一致させて記録する
+    # 状態ファイルはリポジトリ外に置く（リポジトリ内だと未追跡ファイルとして
+    # 差分ハッシュに含まれ、自己無効化してしまうため）
+    local prev_state="$QUALITY_GATE_STATE_FILE"
+    export QUALITY_GATE_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/qg-idempotent-state.XXXXXX")"
+    quality_gate_diff_hash > "$QUALITY_GATE_STATE_FILE"
+    if [[ -s "$QUALITY_GATE_STATE_FILE" ]]; then
+        run_test "Idempotent approval (unchanged diff)" 0 "idempotent_approval.jsonl"
+    else
+        # ハッシュコマンドが無い環境では冪等判定は無効なので stale (2) を許容する
+        echo "⚠️  SKIP: no hash command available, idempotency disabled"
+    fi
+    rm -f "$QUALITY_GATE_STATE_FILE"
+    export QUALITY_GATE_STATE_FILE="$prev_state"
 }
 
 test_valid_approval_no_edits() {

--- a/tests/test-edge-cases.sh
+++ b/tests/test-edge-cases.sh
@@ -8,8 +8,9 @@ set +e
 # Source the common config to get the function
 source "$(dirname "$0")/../plugins/claude-code-quality-gate/scripts/common-config.sh"
 
-# 冪等判定の状態ファイルをテスト用に隔離する（既存の承認記録に汚染されないため）
-# デフォルトは存在しないパスにして「承認済み差分なし」を保証する
+# Isolate the idempotency state file for tests (avoid contamination from
+# existing approval records). Default to a nonexistent path so no diff is
+# considered approved.
 export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-edge-state.XXXXXX")"
 
 # Test counter
@@ -111,16 +112,16 @@ test_idempotent_approval_unchanged_diff() {
 {"parentUuid":"test-uuid","isSidechain":true,"userType":"external","sessionId":"test-session","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Final Result: ✅ APPROVED - Code looks good"}]}}
 {"parentUuid":"test-uuid","isSidechain":false,"userType":"external","sessionId":"test-session","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit"}]}}
 EOF
-    # 承認時点の差分ハッシュを現在の差分に一致させて記録する
-    # 状態ファイルはリポジトリ外に置く（リポジトリ内だと未追跡ファイルとして
-    # 差分ハッシュに含まれ、自己無効化してしまうため）
+    # Record the approved diff hash so it matches the current diff.
+    # Keep the state file outside the repository (inside it, the file would be
+    # hashed as an untracked file and invalidate itself).
     local prev_state="$QUALITY_GATE_STATE_FILE"
     export QUALITY_GATE_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/qg-idempotent-state.XXXXXX")"
     quality_gate_diff_hash > "$QUALITY_GATE_STATE_FILE"
     if [[ -s "$QUALITY_GATE_STATE_FILE" ]]; then
         run_test "Idempotent approval (unchanged diff)" 0 "idempotent_approval.jsonl"
     else
-        # ハッシュコマンドが無い環境では冪等判定は無効なので stale (2) を許容する
+        # Without a hash command idempotency is disabled, so stale (2) is acceptable
         echo "⚠️  SKIP: no hash command available, idempotency disabled"
     fi
     rm -f "$QUALITY_GATE_STATE_FILE"

--- a/tests/test-functions.sh
+++ b/tests/test-functions.sh
@@ -5,7 +5,7 @@
 source "$(dirname "$0")/test-data-common.sh"
 source "$(dirname "$0")/../plugins/claude-code-quality-gate/scripts/common-config.sh"
 
-# 冪等判定の状態ファイルをテスト用に隔離する（存在しないパス = 承認済み差分なし）
+# Isolate the idempotency state file for tests (nonexistent path = no approved diff)
 export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-func-state.XXXXXX")"
 
 # Portable timeout function (works on macOS and Linux)

--- a/tests/test-functions.sh
+++ b/tests/test-functions.sh
@@ -5,6 +5,9 @@
 source "$(dirname "$0")/test-data-common.sh"
 source "$(dirname "$0")/../plugins/claude-code-quality-gate/scripts/common-config.sh"
 
+# 冪等判定の状態ファイルをテスト用に隔離する（存在しないパス = 承認済み差分なし）
+export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-func-state.XXXXXX")"
+
 # Portable timeout function (works on macOS and Linux)
 portable_timeout() {
     local duration=$1

--- a/tests/test-quality-gate-integration.sh
+++ b/tests/test-quality-gate-integration.sh
@@ -14,6 +14,9 @@ QUALITY_GATE_DIR="$PROJECT_ROOT/plugins/claude-code-quality-gate/scripts"
 # Load common test data
 source "$SCRIPT_DIR/test-data-common.sh"
 
+# 冪等判定の状態ファイルをテスト用に隔離する（存在しないパス = 承認済み差分なし）
+export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-integ-state.XXXXXX")"
+
 # Verify quality gate scripts exist
 if [[ ! -f "$QUALITY_GATE_DIR/quality-gate-stop.sh" ]]; then
     echo "❌ Error: quality-gate-stop.sh not found at $QUALITY_GATE_DIR"
@@ -212,6 +215,10 @@ test_task_tool_quality_gate_workflow() {
 # Integration test - Task tool with stale approval 
 test_task_tool_stale_approval() {
     echo "Task tool with stale approval test"
+
+    # 承認記録が無い状態で「承認後の編集」を検知できることを確認する
+    # （別テストの stop.sh が共有状態ファイルに記録するため、専用の空パスに隔離する）
+    export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-integ-stale.XXXXXX")"
     
     # Create transcript: APPROVED in object format, then edits (making approval stale)
     > "$TEST_TRANSCRIPT"

--- a/tests/test-quality-gate-integration.sh
+++ b/tests/test-quality-gate-integration.sh
@@ -14,7 +14,7 @@ QUALITY_GATE_DIR="$PROJECT_ROOT/plugins/claude-code-quality-gate/scripts"
 # Load common test data
 source "$SCRIPT_DIR/test-data-common.sh"
 
-# 冪等判定の状態ファイルをテスト用に隔離する（存在しないパス = 承認済み差分なし）
+# Isolate the idempotency state file for tests (nonexistent path = no approved diff)
 export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-integ-state.XXXXXX")"
 
 # Verify quality gate scripts exist
@@ -216,8 +216,9 @@ test_task_tool_quality_gate_workflow() {
 test_task_tool_stale_approval() {
     echo "Task tool with stale approval test"
 
-    # 承認記録が無い状態で「承認後の編集」を検知できることを確認する
-    # （別テストの stop.sh が共有状態ファイルに記録するため、専用の空パスに隔離する）
+    # Verify that "edits after approval" is detected when no approval is recorded
+    # (another test's stop.sh writes to the shared state file, so isolate with a
+    # dedicated empty path)
     export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-integ-stale.XXXXXX")"
     
     # Create transcript: APPROVED in object format, then edits (making approval stale)

--- a/tests/test-quality-gate-status.sh
+++ b/tests/test-quality-gate-status.sh
@@ -23,7 +23,7 @@ fi
 
 source "$TESTS_DIR/test-data-common.sh"
 
-# 冪等判定の状態ファイルをテスト用に隔離する（存在しないパス = 承認済み差分なし）
+# Isolate the idempotency state file for tests (nonexistent path = no approved diff)
 export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-status-state.XXXXXX")"
 
 # Colors for output

--- a/tests/test-quality-gate-status.sh
+++ b/tests/test-quality-gate-status.sh
@@ -23,6 +23,9 @@ fi
 
 source "$TESTS_DIR/test-data-common.sh"
 
+# 冪等判定の状態ファイルをテスト用に隔離する（存在しないパス = 承認済み差分なし）
+export QUALITY_GATE_STATE_FILE="$(mktemp -u "${TMPDIR:-/tmp}/qg-status-state.XXXXXX")"
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- Record the approved diff hash on APPROVED so the Stop hook no longer re-launches QG on an unchanged diff (edit+revert or unrelated-file edits stay green)
- Take the quality-gate diff against the merge-base with main (configurable via QUALITY_GATE_DIFF_BASE), so committed-but-unmerged changes are gated and working-tree-only diffing is gone
- Update quality-gate-keeper agent instructions to diff against merge-base + untracked files
- Add idempotency test; isolate QUALITY_GATE_STATE_FILE in affected tests
- Bump plugin version to 1.1.0

## Tests
All CI test files pass: test-functions.sh (18), test-quality-gate-status.sh (14), test-edge-cases.sh (11 incl. new), test-quality-gate-integration.sh (14). tests/e2e-test.sh fails identically on main (pre-existing, not in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quality gate checks now support a configurable comparison base and treat unchanged approved diffs as still approved.
  * Added more reliable handling for newly added files and edit detection during status checks.

* **Bug Fixes**
  * Prevents stale approvals from being re-triggered when the diff hasn’t actually changed.
  * Improves consistency across quality gate runs by isolating state per test/run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->